### PR TITLE
Fix build on Python 3.11

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.10.4"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
     license="GPLv3",

--- a/tmtools/io.py
+++ b/tmtools/io.py
@@ -4,7 +4,7 @@ import os
 import warnings
 
 from Bio.PDB.PDBParser import PDBParser
-from Bio.PDB.Polypeptide import three_to_one
+from Bio.PDB.Polypeptide import protein_letters_3to1
 
 import numpy as np
 
@@ -34,6 +34,6 @@ def get_residue_data(chain):
     for residue in chain.get_residues():
         if "CA" in residue.child_dict:
             coords.append(residue.child_dict["CA"].coord)
-            seq.append(three_to_one(residue.resname))
+            seq.append(protein_letters_3to1[residue.resname])
 
     return np.vstack(coords), "".join(seq)


### PR DESCRIPTION
- MAINT: Upgrade pybind11 version
- MAINT: Removed deprecated three_to_one
- TST: Test on Python 3.11

Fixes #14