### PR TITLE
FIX: Fall back to Bio.PDB.protein_letters_3to1 for BioPython <= 1.79

### DIFF
--- a/tmtools/io.py
+++ b/tmtools/io.py
@@ -4,7 +4,11 @@ import os
 import warnings
 
 from Bio.PDB.PDBParser import PDBParser
-from Bio.PDB.Polypeptide import protein_letters_3to1
+try:
+    from Bio.PDB.Polypeptide import protein_letters_3to1
+except ImportError:
+    # pre 1.80
+    from Bio.PDB import protein_letters_3to1
 
 import numpy as np
 


### PR DESCRIPTION
Fixes #21 

The `protein_letters_3to1` dictionary has moved around in recent versions of BioPython. While it is recommended to use the most recent version of BioPython, the fix to support (at least) version 1.79 is sufficiently straightforward to make it worth doing.