### PR TITLE
ENH: Add optional user-defined alignment to tm_align function

### DIFF
--- a/src/_wrapper.cpp
+++ b/src/_wrapper.cpp
@@ -7,11 +7,12 @@
 void _tmalign_wrapper(double **xa, double **ya, const char *seqx,
                       const char *seqy, const int xlen, const int ylen,
                       double t0[3], double u0[3][3], double &TM1, double &TM2, double &rmsd0,
-                      std::string &seqM, std::string &seqxA, std::string &seqyA)
+                      std::string &seqM, std::string &seqxA, std::string &seqyA,
+                      const std::vector<std::string> &user_alignment)
 
 {
-  // user alignment
-  std::vector<std::string> sequence; // get value from alignment file
+  // user alignment - use provided alignment or empty vector for automatic alignment
+  std::vector<std::string> sequence = user_alignment;
 
   // sequences and coordinates
   char *secx = new char[xlen + 1];
@@ -21,7 +22,7 @@ void _tmalign_wrapper(double **xa, double **ya, const char *seqx,
   make_sec(ya, ylen, secy);
 
   // parameters (currently hardcoded)
-  int i_opt = 0;         // 1 for -i, 3 for -I
+  int i_opt = (sequence.size() == 2) ? 3 : 0; // 3 for user alignment, 0 for automatic
   int a_opt = 0;         // flag for -a, do not normalized by average length
   bool u_opt = false;    // flag for -u, normalized by user specified length
   bool d_opt = false;    // flag for -d, user specified d0

--- a/src/_wrapper.h
+++ b/src/_wrapper.h
@@ -4,6 +4,7 @@
 void _tmalign_wrapper(double **xa, double **ya, const char *seqx,
                       const char *seqy, const int xlen, const int ylen,
                       double t0[3], double u0[3][3], double &TM1, double &TM2, double &rmsd0,
-                      std::string &seqM, std::string &seqxA, std::string &seqyA);
+                      std::string &seqM, std::string &seqxA, std::string &seqyA,
+                      const std::vector<std::string> &user_alignment = std::vector<std::string>());
 
 #endif // _TMALIGN_WRAPPER_H_


### PR DESCRIPTION
- Updated tm_align to accept an optional alignment parameter as a list/tuple of two aligned sequences.
- Added validation to ensure the provided sequences match the input sequences without gaps.
- Modified _tmalign_wrapper to handle user-defined alignments, adjusting internal logic accordingly.
- Updated documentation to reflect the new alignment parameter.