### PR TITLE
FIX: Update GitHub Actions artifact actions to v4

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,6 +25,7 @@ jobs:
         CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
         CIBW_ARCHS_MACOS: "x86_64 arm64"
         CIBW_SKIP: "pp3*"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl

--- a/.github/workflows/make-sdist.yml
+++ b/.github/workflows/make-sdist.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: build sdist
       run: pipx run build --sdist
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
+        name: sdist
         path: dist/*.tar.gz

--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -10,9 +10,10 @@ jobs:
       name: pypi
       url: https://pypi.org/p/tmtools 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: '*'
+          merge-multiple: true
           path: wheelhouse/
       - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,9 @@ ruff check .
 
 **3. Commit and tag:**
 - Commit the version number changes
-- Create a git tag with format `vX.Y.Z` (e.g., `v0.3.0`)
+- Create an annotated git tag with format `vX.Y.Z` (e.g., `v0.3.0`)
 - The tag should point to the commit that changes the version numbers
-- Example: `git tag v0.3.0 && git push origin v0.3.0`
+- Example: `git tag -a v0.3.0 -m "Release v0.3.0" && git push origin v0.3.0`
 
 **4. Create GitHub release:**
 - Publish a new GitHub release using the tag created above


### PR DESCRIPTION
## Summary

- Update `actions/upload-artifact` from v2/v3 to v4 in all workflows
- Update `actions/download-artifact` from v3 to v4
- Use unique artifact names per OS for wheels to avoid conflicts
- Use pattern matching to download and merge all artifacts in upload-pypi workflow
- Document requirement for annotated tags in CLAUDE.md

## Context

This fixes the build failure in the v0.3.0 release caused by deprecated artifact actions. GitHub deprecated v1-v3 of the artifact actions, and workflows were failing with automatic deprecation errors.

## Changes

- `.github/workflows/build-wheels.yml`: Update upload to v4 with unique artifact names per OS
- `.github/workflows/make-sdist.yml`: Update upload to v4 with unique artifact name
- `.github/workflows/upload-pypi.yml`: Update download to v4 with pattern matching to merge all artifacts
- `CLAUDE.md`: Document that annotated tags (`git tag -a`) are required

## Test plan

- [ ] Merge PR and verify workflows pass
- [ ] Re-run the v0.3.0 release workflow to complete PyPI upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)